### PR TITLE
refactor: change module logic to match the Ubercart flow

### DIFF
--- a/ya_ubercart/ya_ubercart.module
+++ b/ya_ubercart/ya_ubercart.module
@@ -147,9 +147,9 @@ function ya_ubercart_yamoney_process_payment_alter(&$payment) {
   $order = uc_order_load($transaction->order_id);
   if ($order) {
     //print_r($order);
+    uc_payment_enter($order->order_id, 'ya_ubercart', $transaction->amount, $order->uid, NULL, t('Yandex.Money transaction ID: @txn_id', array('@txn_id' => $transaction->ymid)));
     uc_cart_complete_sale($order);
     uc_cart_empty($order->uid);
-    uc_order_update_status($order->order_id, 'payment_received');
     $payment['success'] = TRUE;
   }
   else {

--- a/ya_ubercart/ya_ubercart.module
+++ b/ya_ubercart/ya_ubercart.module
@@ -150,6 +150,7 @@ function ya_ubercart_yamoney_process_payment_alter(&$payment) {
     uc_payment_enter($order->order_id, 'ya_ubercart', $transaction->amount, $order->uid, NULL, t('Yandex.Money transaction ID: @txn_id', array('@txn_id' => $transaction->ymid)));
     uc_cart_complete_sale($order);
     uc_cart_empty($order->uid);
+    uc_order_comment_save($order->order_id, 0, t('Yandex.Money reported a payment of @amount @currency.', array('@amount' => uc_currency_format($transaction->amount, FALSE), '@currency' => $order->currency)));
     $payment['success'] = TRUE;
   }
   else {


### PR DESCRIPTION
- В функции `ya_ubercart_yamoney_process_payment_alter` (имплементация хука `hook_yamoney_process_payment_alter`) добавлен вызов функции добавления автоматического комментария к заказу при успешном  завершении заказа.
- Процесс завершения оплаты в модуле `ya_ubercart` приведен в соответствие с логикой работы платежных модулей для Ubercart - в функции y`a_ubercart_yamoney_process_payment_alter` (имплементация хука `hook_yamoney_process_payment_alter`) убран вызов функции `uc_order_update_status`, вместо него добавлен вызов функции `uc_payment_enter`).